### PR TITLE
[feat] add websocket endpoint for room gameplay

### DIFF
--- a/backend/internal/modules/game/game_room.go
+++ b/backend/internal/modules/game/game_room.go
@@ -1,0 +1,315 @@
+package game
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"awkit-example-snake-arena-backend/internal/ws"
+)
+
+// MessageEnvelope wraps outbound WebSocket messages with a type discriminator.
+type MessageEnvelope struct {
+	Type string      `json:"type"`
+	Data interface{} `json:"data,omitempty"`
+}
+
+// SnapshotPayload is sent when a client first connects.
+type SnapshotPayload struct {
+	RoomID string     `json:"roomId"`
+	State  *GameState `json:"state"`
+}
+
+// TickPayload delivers tick outcomes alongside the latest state snapshot.
+type TickPayload struct {
+	RoomID string     `json:"roomId"`
+	State  *GameState `json:"state"`
+	Tick   TickResult `json:"tick"`
+}
+
+// RoomConfig defines defaults for new rooms.
+type RoomConfig struct {
+	TickInterval time.Duration
+	Grid         Grid
+	Seed         int64
+}
+
+// RoomManager manages room lifecycle and acts as the HTTP handler.
+type RoomManager struct {
+	mu     sync.Mutex
+	rooms  map[string]*Room
+	config RoomConfig
+}
+
+// NewRoomManager constructs a manager with sane defaults.
+func NewRoomManager(config RoomConfig) *RoomManager {
+	if config.TickInterval <= 0 {
+		config.TickInterval = 200 * time.Millisecond
+	}
+	if config.Grid.Width == 0 || config.Grid.Height == 0 {
+		config.Grid = Grid{Width: 15, Height: 15}
+	}
+	if config.Seed == 0 {
+		config.Seed = 1
+	}
+
+	return &RoomManager{
+		rooms:  make(map[string]*Room),
+		config: config,
+	}
+}
+
+// ServeHTTP upgrades the connection and attaches the client to a room.
+func (m *RoomManager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if !strings.HasPrefix(r.URL.Path, "/ws/rooms/") {
+		http.NotFound(w, r)
+		return
+	}
+
+	roomID := strings.TrimPrefix(r.URL.Path, "/ws/rooms/")
+	roomID = strings.Trim(roomID, "/")
+	if roomID == "" {
+		http.Error(w, "room id required", http.StatusBadRequest)
+		return
+	}
+
+	conn, err := ws.Upgrade(w, r)
+	if err != nil {
+		http.Error(w, "websocket upgrade failed", http.StatusBadRequest)
+		return
+	}
+
+	room := m.getOrCreateRoom(roomID)
+	room.addClient(conn)
+}
+
+// Shutdown stops all active rooms.
+func (m *RoomManager) Shutdown() {
+	m.mu.Lock()
+	rooms := make([]*Room, 0, len(m.rooms))
+	for _, room := range m.rooms {
+		rooms = append(rooms, room)
+	}
+	m.rooms = make(map[string]*Room)
+	m.mu.Unlock()
+
+	for _, room := range rooms {
+		room.Stop()
+	}
+}
+
+// RoomClientCount returns the number of clients in a room (primarily for tests).
+func (m *RoomManager) RoomClientCount(roomID string) int {
+	m.mu.Lock()
+	room := m.rooms[roomID]
+	m.mu.Unlock()
+	if room == nil {
+		return 0
+	}
+	return room.ClientCount()
+}
+
+func (m *RoomManager) getOrCreateRoom(roomID string) *Room {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if room, ok := m.rooms[roomID]; ok {
+		return room
+	}
+
+	room := newRoom(roomID, m.config, m.handleRoomEmpty)
+	m.rooms[roomID] = room
+	return room
+}
+
+func (m *RoomManager) handleRoomEmpty(roomID string) {
+	m.mu.Lock()
+	room, ok := m.rooms[roomID]
+	if ok {
+		delete(m.rooms, roomID)
+	}
+	m.mu.Unlock()
+
+	if ok {
+		room.Stop()
+	}
+}
+
+type Room struct {
+	id           string
+	engine       *TickEngine
+	state        *GameState
+	tickInterval time.Duration
+	clients      map[*client]struct{}
+	mu           sync.RWMutex
+	stop         chan struct{}
+	stopOnce     sync.Once
+	onEmpty      func(string)
+}
+
+func newRoom(id string, config RoomConfig, onEmpty func(string)) *Room {
+	room := &Room{
+		id:           id,
+		engine:       NewTickEngine(config.Seed + int64(len(id))),
+		state:        defaultState(config.Grid),
+		tickInterval: config.TickInterval,
+		clients:      make(map[*client]struct{}),
+		stop:         make(chan struct{}),
+		onEmpty:      onEmpty,
+	}
+
+	go room.run()
+	return room
+}
+
+func (r *Room) run() {
+	ticker := time.NewTicker(r.tickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			r.handleTick()
+		case <-r.stop:
+			return
+		}
+	}
+}
+
+func (r *Room) addClient(conn *ws.Conn) {
+	client := newClient(r, conn)
+
+	r.mu.Lock()
+	r.clients[client] = struct{}{}
+	snapshot := CloneState(r.state)
+	r.mu.Unlock()
+
+	client.start()
+	r.sendToClient(client, MessageEnvelope{
+		Type: "snapshot",
+		Data: SnapshotPayload{RoomID: r.id, State: snapshot},
+	})
+}
+
+func (r *Room) handleTick() {
+	r.mu.Lock()
+	result := r.engine.Tick(r.state)
+	snapshot := CloneState(r.state)
+	clients := r.copyClientsLocked()
+	r.mu.Unlock()
+
+	if len(clients) == 0 || snapshot == nil {
+		return
+	}
+
+	payload := MessageEnvelope{
+		Type: "tick",
+		Data: TickPayload{
+			RoomID: r.id,
+			State:  snapshot,
+			Tick:   result,
+		},
+	}
+	r.broadcast(payload, clients)
+}
+
+func (r *Room) broadcast(message MessageEnvelope, targets []*client) {
+	data, err := json.Marshal(message)
+	if err != nil {
+		return
+	}
+	for _, c := range targets {
+		r.queueMessage(c, data)
+	}
+}
+
+func (r *Room) sendToClient(c *client, message MessageEnvelope) {
+	r.broadcast(message, []*client{c})
+}
+
+func (r *Room) queueMessage(c *client, data []byte) {
+	select {
+	case c.send <- data:
+	default:
+		r.removeClient(c)
+	}
+}
+
+func (r *Room) removeClient(c *client) {
+	r.mu.Lock()
+	if _, ok := r.clients[c]; !ok {
+		r.mu.Unlock()
+		return
+	}
+	delete(r.clients, c)
+	empty := len(r.clients) == 0
+	r.mu.Unlock()
+
+	c.close()
+	if empty && r.onEmpty != nil {
+		r.onEmpty(r.id)
+	}
+}
+
+// Stop halts ticking and closes client connections.
+func (r *Room) Stop() {
+	r.stopOnce.Do(func() {
+		close(r.stop)
+
+		r.mu.Lock()
+		clients := make([]*client, 0, len(r.clients))
+		for c := range r.clients {
+			clients = append(clients, c)
+		}
+		r.clients = make(map[*client]struct{})
+		r.mu.Unlock()
+
+		for _, c := range clients {
+			c.close()
+		}
+	})
+}
+
+// ClientCount exposes the current number of clients attached to the room.
+func (r *Room) ClientCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.clients)
+}
+
+func (r *Room) copyClientsLocked() []*client {
+	clients := make([]*client, 0, len(r.clients))
+	for c := range r.clients {
+		clients = append(clients, c)
+	}
+	return clients
+}
+
+func defaultState(grid Grid) *GameState {
+	if grid.Width == 0 || grid.Height == 0 {
+		grid = Grid{Width: 15, Height: 15}
+	}
+
+	snakeID := "snake-1"
+	return &GameState{
+		Grid: grid,
+		Snakes: map[string]*Snake{
+			snakeID: {
+				ID:        snakeID,
+				Body:      []Position{{X: 1, Y: 1}},
+				Direction: DirectionRight,
+				Alive:     true,
+			},
+		},
+		Food: []Position{
+			{X: grid.Width / 2, Y: grid.Height / 2},
+		},
+	}
+}

--- a/backend/internal/modules/game/game_room_client.go
+++ b/backend/internal/modules/game/game_room_client.go
@@ -1,0 +1,72 @@
+package game
+
+import (
+	"sync"
+
+	"awkit-example-snake-arena-backend/internal/ws"
+)
+
+type client struct {
+	room *Room
+	conn *ws.Conn
+	send chan []byte
+	done chan struct{}
+	once sync.Once
+}
+
+func newClient(room *Room, conn *ws.Conn) *client {
+	return &client{
+		room: room,
+		conn: conn,
+		send: make(chan []byte, 16),
+		done: make(chan struct{}),
+	}
+}
+
+func (c *client) start() {
+	go c.readLoop()
+	go c.writeLoop()
+}
+
+func (c *client) readLoop() {
+	for {
+		opcode, payload, err := c.conn.Read()
+		if err != nil {
+			break
+		}
+		switch opcode {
+		case ws.OpClose:
+			_ = c.conn.WriteClose()
+			return
+		case ws.OpPing:
+			_ = c.conn.WritePong(payload)
+		}
+	}
+
+	c.room.removeClient(c)
+}
+
+func (c *client) writeLoop() {
+	for {
+		select {
+		case msg, ok := <-c.send:
+			if !ok {
+				return
+			}
+			if err := c.conn.WriteText(msg); err != nil {
+				c.room.removeClient(c)
+				return
+			}
+		case <-c.done:
+			return
+		}
+	}
+}
+
+func (c *client) close() {
+	c.once.Do(func() {
+		close(c.done)
+		close(c.send)
+		_ = c.conn.Close()
+	})
+}

--- a/backend/internal/modules/game/game_room_test.go
+++ b/backend/internal/modules/game/game_room_test.go
@@ -1,0 +1,253 @@
+package game
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"awkit-example-snake-arena-backend/internal/ws"
+)
+
+func TestWebSocketRoomLifecycle(t *testing.T) {
+	manager := NewRoomManager(RoomConfig{
+		TickInterval: 15 * time.Millisecond,
+		Grid:         Grid{Width: 6, Height: 6},
+		Seed:         99,
+	})
+	defer manager.Shutdown()
+
+	conn, reader := openWebSocket(t, manager, "/ws/rooms/test-room")
+	defer conn.Close()
+
+	first := readEnvelope(t, conn, reader)
+	if first.Type != "snapshot" {
+		t.Fatalf("expected first message to be snapshot, got %s", first.Type)
+	}
+
+	tick := waitForType(t, conn, reader, "tick")
+	var payload TickPayload
+	decodeData(t, tick.Data, &payload)
+
+	if payload.RoomID != "test-room" {
+		t.Fatalf("expected room id test-room, got %s", payload.RoomID)
+	}
+
+	if payload.State == nil || len(payload.State.Snakes) == 0 {
+		t.Fatalf("expected a populated state snapshot, got %+v", payload.State)
+	}
+
+	if got := manager.RoomClientCount("test-room"); got != 1 {
+		t.Fatalf("expected 1 client registered, got %d", got)
+	}
+
+	_ = conn.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	if got := manager.RoomClientCount("test-room"); got != 0 {
+		t.Fatalf("expected client to be removed after close, got %d", got)
+	}
+}
+
+func TestBroadcastTickToMultipleClients(t *testing.T) {
+	manager := NewRoomManager(RoomConfig{
+		TickInterval: 10 * time.Millisecond,
+		Grid:         Grid{Width: 5, Height: 5},
+		Seed:         7,
+	})
+	defer manager.Shutdown()
+
+	connA, readerA := openWebSocket(t, manager, "/ws/rooms/shared")
+	defer connA.Close()
+	connB, readerB := openWebSocket(t, manager, "/ws/rooms/shared")
+	defer connB.Close()
+
+	_ = readEnvelope(t, connA, readerA) // snapshot
+	_ = readEnvelope(t, connB, readerB) // snapshot
+
+	tickA := waitForType(t, connA, readerA, "tick")
+	tickB := waitForType(t, connB, readerB, "tick")
+
+	var payloadA, payloadB TickPayload
+	decodeData(t, tickA.Data, &payloadA)
+	decodeData(t, tickB.Data, &payloadB)
+
+	if payloadA.RoomID != "shared" || payloadB.RoomID != "shared" {
+		t.Fatalf("expected room id shared, got %s and %s", payloadA.RoomID, payloadB.RoomID)
+	}
+
+	if len(payloadA.State.Snakes) == 0 || len(payloadB.State.Snakes) == 0 {
+		t.Fatalf("expected state to include snakes")
+	}
+}
+
+type pipeResponseWriter struct {
+	header http.Header
+	conn   net.Conn
+}
+
+func (w *pipeResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *pipeResponseWriter) Write(p []byte) (int, error) {
+	return w.conn.Write(p)
+}
+
+func (w *pipeResponseWriter) WriteHeader(statusCode int) {}
+
+func (w *pipeResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	rw := bufio.NewReadWriter(bufio.NewReader(w.conn), bufio.NewWriter(w.conn))
+	return w.conn, rw, nil
+}
+
+func openWebSocket(t *testing.T, manager *RoomManager, path string) (net.Conn, *bufio.Reader) {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com"+path, nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+	req.Header.Set("Sec-WebSocket-Key", base64.StdEncoding.EncodeToString([]byte("client-key")))
+
+	writer := &pipeResponseWriter{
+		header: http.Header{},
+		conn:   serverConn,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		manager.ServeHTTP(writer, req)
+		close(done)
+	}()
+
+	reader := bufio.NewReader(clientConn)
+	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	verifyHandshake(t, reader)
+	_ = clientConn.SetReadDeadline(time.Time{})
+	<-done
+	return clientConn, reader
+}
+
+func verifyHandshake(t *testing.T, reader *bufio.Reader) {
+	t.Helper()
+	status, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read handshake status: %v", err)
+	}
+	if !strings.Contains(status, "101") {
+		t.Fatalf("expected status 101, got %s", strings.TrimSpace(status))
+	}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read handshake headers: %v", err)
+		}
+		if line == "\r\n" || line == "\n" {
+			break
+		}
+	}
+}
+
+func readEnvelope(t *testing.T, conn net.Conn, reader *bufio.Reader) MessageEnvelope {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	opcode, payload := readFrame(t, reader)
+	if opcode != ws.OpText {
+		t.Fatalf("expected text frame opcode, got %d", opcode)
+	}
+	return decodeEnvelope(t, payload)
+}
+
+func waitForType(t *testing.T, conn net.Conn, reader *bufio.Reader, desired string) MessageEnvelope {
+	t.Helper()
+	for attempts := 0; attempts < 10; attempts++ {
+		env := readEnvelope(t, conn, reader)
+		if env.Type == desired {
+			return env
+		}
+	}
+	t.Fatalf("did not receive message type %s", desired)
+	return MessageEnvelope{}
+}
+
+func decodeEnvelope(t *testing.T, payload []byte) MessageEnvelope {
+	t.Helper()
+	var env MessageEnvelope
+	if err := json.Unmarshal(payload, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	return env
+}
+
+func decodeData[T any](t *testing.T, data interface{}, target *T) {
+	t.Helper()
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal data: %v", err)
+	}
+	if err := json.Unmarshal(bytes, target); err != nil {
+		t.Fatalf("unmarshal data: %v", err)
+	}
+}
+
+func readFrame(t *testing.T, r *bufio.Reader) (byte, []byte) {
+	t.Helper()
+	first, err := r.ReadByte()
+	if err != nil {
+		t.Fatalf("read frame first byte: %v", err)
+	}
+	second, err := r.ReadByte()
+	if err != nil {
+		t.Fatalf("read frame second byte: %v", err)
+	}
+
+	opcode := first & 0x0F
+	masked := second&0x80 != 0
+	length := int64(second & 0x7F)
+
+	switch length {
+	case 126:
+		var ext [2]byte
+		if _, err := r.Read(ext[:]); err != nil {
+			t.Fatalf("read extended length: %v", err)
+		}
+		length = int64(ext[0])<<8 | int64(ext[1])
+	case 127:
+		var ext [8]byte
+		if _, err := r.Read(ext[:]); err != nil {
+			t.Fatalf("read extended length 64: %v", err)
+		}
+		length = int64(ext[0])<<56 | int64(ext[1])<<48 | int64(ext[2])<<40 | int64(ext[3])<<32 |
+			int64(ext[4])<<24 | int64(ext[5])<<16 | int64(ext[6])<<8 | int64(ext[7])
+	}
+
+	var maskKey [4]byte
+	if masked {
+		if _, err := r.Read(maskKey[:]); err != nil {
+			t.Fatalf("read mask key: %v", err)
+		}
+	}
+
+	payload := make([]byte, length)
+	if length > 0 {
+		if _, err := r.Read(payload); err != nil {
+			t.Fatalf("read payload: %v", err)
+		}
+	}
+
+	if masked {
+		for i := int64(0); i < length; i++ {
+			payload[i] ^= maskKey[i%4]
+		}
+	}
+
+	return opcode, payload
+}

--- a/backend/internal/modules/game/game_state_copy.go
+++ b/backend/internal/modules/game/game_state_copy.go
@@ -1,0 +1,28 @@
+package game
+
+// CloneState creates a deep copy of the provided game state.
+func CloneState(state *GameState) *GameState {
+	if state == nil {
+		return nil
+	}
+
+	snakes := make(map[string]*Snake, len(state.Snakes))
+	for id, snake := range state.Snakes {
+		if snake == nil {
+			continue
+		}
+		bodyCopy := append([]Position(nil), snake.Body...)
+		snakes[id] = &Snake{
+			ID:        snake.ID,
+			Body:      bodyCopy,
+			Direction: snake.Direction,
+			Alive:     snake.Alive,
+		}
+	}
+
+	return &GameState{
+		Grid:   state.Grid,
+		Snakes: snakes,
+		Food:   append([]Position(nil), state.Food...),
+	}
+}

--- a/backend/internal/ws/ws.go
+++ b/backend/internal/ws/ws.go
@@ -1,0 +1,209 @@
+package ws
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const (
+	OpText  byte = 0x1
+	OpClose byte = 0x8
+	OpPing  byte = 0x9
+	OpPong  byte = 0xA
+)
+
+const websocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+// Conn is a minimal WebSocket connection that supports text frames,
+// ping/pong, and close frames. It intentionally avoids third-party
+// dependencies to keep the build offline-friendly.
+type Conn struct {
+	conn   net.Conn
+	rw     *bufio.ReadWriter
+	writeM sync.Mutex
+}
+
+// Upgrade upgrades an HTTP request to a WebSocket connection.
+func Upgrade(w http.ResponseWriter, r *http.Request) (*Conn, error) {
+	if strings.ToLower(r.Header.Get("Upgrade")) != "websocket" {
+		return nil, errors.New("missing websocket upgrade header")
+	}
+
+	if !headerContainsToken(r.Header.Values("Connection"), "upgrade") {
+		return nil, errors.New("missing connection upgrade token")
+	}
+
+	if r.Header.Get("Sec-WebSocket-Version") != "13" {
+		return nil, errors.New("unsupported websocket version")
+	}
+
+	key := strings.TrimSpace(r.Header.Get("Sec-WebSocket-Key"))
+	if key == "" {
+		return nil, errors.New("missing websocket key")
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		return nil, errors.New("hijacking not supported")
+	}
+
+	netConn, rw, err := hijacker.Hijack()
+	if err != nil {
+		return nil, err
+	}
+
+	acceptKey := computeAcceptKey(key)
+	response := fmt.Sprintf("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", acceptKey)
+
+	if _, err := rw.WriteString(response); err != nil {
+		netConn.Close()
+		return nil, err
+	}
+	if err := rw.Flush(); err != nil {
+		netConn.Close()
+		return nil, err
+	}
+
+	return &Conn{conn: netConn, rw: rw}, nil
+}
+
+// WriteText writes a text frame to the connection.
+func (c *Conn) WriteText(payload []byte) error {
+	return c.writeFrame(OpText, payload)
+}
+
+// WritePong writes a pong frame to respond to a ping.
+func (c *Conn) WritePong(payload []byte) error {
+	return c.writeFrame(OpPong, payload)
+}
+
+// WriteClose writes a close frame and closes the connection.
+func (c *Conn) WriteClose() error {
+	_ = c.writeFrame(OpClose, nil)
+	return c.conn.Close()
+}
+
+// Read reads the next WebSocket frame opcode and payload.
+func (c *Conn) Read() (byte, []byte, error) {
+	return readFrame(c.rw.Reader)
+}
+
+// Close closes the underlying network connection.
+func (c *Conn) Close() error {
+	return c.conn.Close()
+}
+
+func (c *Conn) writeFrame(opcode byte, payload []byte) error {
+	c.writeM.Lock()
+	defer c.writeM.Unlock()
+
+	if err := writeFrame(c.rw.Writer, opcode, payload); err != nil {
+		return err
+	}
+	return c.rw.Flush()
+}
+
+func computeAcceptKey(key string) string {
+	hash := sha1.Sum([]byte(key + websocketGUID))
+	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+func headerContainsToken(values []string, token string) bool {
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), token) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func writeFrame(w io.Writer, opcode byte, payload []byte) error {
+	header := []byte{0x80 | opcode}
+	length := len(payload)
+	length64 := uint64(length)
+
+	switch {
+	case length <= 125:
+		header = append(header, byte(length))
+	case length <= 65535:
+		header = append(header, 126, byte(length>>8), byte(length))
+	default:
+		header = append(header, 127,
+			byte(length64>>56), byte(length64>>48), byte(length64>>40), byte(length64>>32),
+			byte(length64>>24), byte(length64>>16), byte(length64>>8), byte(length64))
+	}
+
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	if length > 0 {
+		if _, err := w.Write(payload); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readFrame(r *bufio.Reader) (byte, []byte, error) {
+	first, err := r.ReadByte()
+	if err != nil {
+		return 0, nil, err
+	}
+	second, err := r.ReadByte()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	opcode := first & 0x0F
+	masked := second&0x80 != 0
+	length := int64(second & 0x7F)
+
+	switch length {
+	case 126:
+		var extended [2]byte
+		if _, err := io.ReadFull(r, extended[:]); err != nil {
+			return 0, nil, err
+		}
+		length = int64(extended[0])<<8 | int64(extended[1])
+	case 127:
+		var extended [8]byte
+		if _, err := io.ReadFull(r, extended[:]); err != nil {
+			return 0, nil, err
+		}
+		length = int64(extended[0])<<56 | int64(extended[1])<<48 | int64(extended[2])<<40 | int64(extended[3])<<32 |
+			int64(extended[4])<<24 | int64(extended[5])<<16 | int64(extended[6])<<8 | int64(extended[7])
+	}
+
+	var maskKey [4]byte
+	if masked {
+		if _, err := io.ReadFull(r, maskKey[:]); err != nil {
+			return 0, nil, err
+		}
+	}
+
+	payload := make([]byte, length)
+	if length > 0 {
+		if _, err := io.ReadFull(r, payload); err != nil {
+			return 0, nil, err
+		}
+	}
+
+	if masked {
+		for i := int64(0); i < length; i++ {
+			payload[i] ^= maskKey[i%4]
+		}
+	}
+
+	return opcode, payload, nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,7 +1,29 @@
 package main
 
-import "fmt"
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"awkit-example-snake-arena-backend/internal/modules/game"
+)
 
 func main() {
-	fmt.Println("Hello, World!")
+	manager := game.NewRoomManager(game.RoomConfig{})
+	mux := http.NewServeMux()
+	mux.Handle("/ws/rooms/", manager)
+
+	addr := ":" + port()
+	log.Printf("starting websocket server on %s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatalf("server stopped: %v", err)
+	}
+}
+
+func port() string {
+	p := os.Getenv("PORT")
+	if p == "" {
+		return "8080"
+	}
+	return p
 }


### PR DESCRIPTION
Closes #8

## Summary
- Added room manager and WebSocket handling at `/ws/rooms/{roomId}` using snapshot/tick JSON envelopes
- Implemented per-connection handling, state cloning, and clean disconnect support
- Wired HTTP server to expose WebSocket endpoint on PORT (default 8080)
- Added tests covering connection lifecycle and multi-client broadcasts

## Implementation
- `backend/internal/modules/game/game_room.go` - Room manager and room logic
- `backend/internal/modules/game/game_room_client.go` - Client connection handling
- `backend/internal/modules/game/game_state_copy.go` - State cloning utility
- `backend/internal/ws/ws.go` - Minimal WebSocket upgrade handler
- `backend/main.go` - HTTP server setup
- `backend/internal/modules/game/game_room_test.go` - Integration tests

## Verification
- Build: `cd backend && go build ./...` ✓
- Test: `cd backend && go test ./...` ✓